### PR TITLE
fix bug for generating vectors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 Run `./scripts/generate_all_vectors.sh` to run the llama 2 7b experiments
 Run `./scripts/generate_13b.sh` to additionally run the llama 2 13b experiments
+
+You may have to export your huggingface API key:
+`export HF_TOKEN="hf_Q...."`

--- a/generate_vectors.py
+++ b/generate_vectors.py
@@ -31,7 +31,7 @@ class ComparisonDataset(Dataset):
             self.data = json.load(f)
         self.system_prompt = system_prompt
         self.tokenizer = AutoTokenizer.from_pretrained(
-            model_name_path, use_auth_token=token
+            model_name_path, token=token
         )
         self.tokenizer.pad_token = self.tokenizer.eos_token
         self.use_chat = use_chat

--- a/llama_wrapper.py
+++ b/llama_wrapper.py
@@ -37,11 +37,11 @@ class LlamaWrapper:
         else:
             self.model_name_path = f"meta-llama/Llama-2-{size}-hf"
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name_path, use_auth_token=token
+            self.model_name_path, token=token
         )
         self.model = (
             AutoModelForCausalLM.from_pretrained(
-                self.model_name_path, use_auth_token=token
+                self.model_name_path, token=token
             )
             .half()
             .to(self.device)

--- a/scripts/generate_all_vectors.sh
+++ b/scripts/generate_all_vectors.sh
@@ -23,7 +23,7 @@ python generate_vectors.py --layers $(seq 0 31) --model_size "7b" --data_path da
 python generate_vectors.py --layers $(seq 0 31) --model_size "7b" --use_base_model --data_path datasets/myopic.json --dataset_name myopic
 python analyze_vectors.py --dataset_name myopic
 
-python analyze_vectors.py --dataset_name myopic-layers $(seq 0 31) --model_size "7b" --data_path datasets/conscientiousness.json --dataset_name conscientiousness
+python generate_vectors.py --layers $(seq 0 31) --model_size "7b" --data_path datasets/conscientiousness.json --dataset_name conscientiousness
 python generate_vectors.py --layers $(seq 0 31) --model_size "7b" --use_base_model --data_path datasets/conscientiousness.json --dataset_name conscientiousness
 python analyze_vectors.py --dataset_name conscientiousness
 


### PR DESCRIPTION
So at the moment scripts/generate_all_vectors.sh does not properly work because line 26 is calling the wrong file (analyze_vectors.py instead of generate_vectors.py)
This does not have any result on the output, as the vectors directory already contains all the vector files, however this means it just uses the old vectors instead of generating them for the dataset of conscientiousness

also: less warnings about use_auth_token